### PR TITLE
Use erlang halt vs init stop in Makefile

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -20,7 +20,7 @@ endif
 
 # Project specific C compiler/flags.
 ifeq ($(ERTS_INCLUDE_DIR),)
-	ERTS_INCLUDE_DIR := $(shell "$(ERL)" -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
+	ERTS_INCLUDE_DIR := $(shell "$(ERL)" -noshell -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)])." -s erlang halt)
 endif
 
 CFLAGS += -std=c11 -fPIC -I $(ERTS_INCLUDE_DIR)


### PR DESCRIPTION
In Erlang/OTP 26 a race condition was uncovered when using `-eval` with `-s init stop` (i.e., it was always there, but most of the community lucked out in not running into it).

See https://github.com/erlang/otp/issues/6916 for details